### PR TITLE
feat(json_decoder): Add items_count to the json_decoder constructor

### DIFF
--- a/include/jsoncons/json_decoder.hpp
+++ b/include/jsoncons/json_decoder.hpp
@@ -66,7 +66,8 @@ private:
 
 public:
     json_decoder(const allocator_type& alloc = allocator_type(), 
-        const temp_allocator_type& temp_alloc = temp_allocator_type())
+        const temp_allocator_type& temp_alloc = temp_allocator_type(),
+        size_t items_count = 1000)
         : allocator_(alloc),
           result_(),
           index_(0),
@@ -75,9 +76,7 @@ public:
           structure_stack_(temp_alloc),
           is_valid_(false)
     {
-        item_stack_.reserve(1000);
-        structure_stack_.reserve(100);
-        structure_stack_.emplace_back(structure_type::root_t, 0);
+        Initialize(items_count, items_count / 10);
     }
 
     json_decoder(temp_allocator_arg_t, 
@@ -90,9 +89,7 @@ public:
           structure_stack_(temp_alloc),
           is_valid_(false)
     {
-        item_stack_.reserve(1000);
-        structure_stack_.reserve(100);
-        structure_stack_.emplace_back(structure_type::root_t, 0);
+        Initialize(1000,100);
     }
 
 #if !defined(JSONCONS_NO_DEPRECATED)
@@ -133,6 +130,13 @@ public:
 #endif
 
 private:
+
+    void Initialize(size_t items_count, size_t structures_count)
+    {
+        item_stack_.reserve(items_count);
+        structure_stack_.reserve(structures_count);
+        structure_stack_.emplace_back(structure_type::root_t, 0);
+    }
 
     void visit_flush() override
     {


### PR DESCRIPTION
Now we can reduce amount of the elements which we are reserving during json_decoder ctor.

In Dragonfly repo we will use it like this:
```

json_decoder<JsonType> decoder(alloc, temp_alloc, input.size());
```

[Inspired by this discussion](https://github.com/danielaparker/jsoncons/issues/531#issuecomment-2293758437)