### PR TITLE
[only for review/dnm] Drops `compute_memory_size` and related changes from fork

### DIFF
--- a/include/jsoncons/json_encoder.hpp
+++ b/include/jsoncons/json_encoder.hpp
@@ -329,7 +329,6 @@ namespace detail {
 
         Sink sink_;
         basic_json_encode_options<CharT> options_;
-        char_type indent_char_{' '};
         jsoncons::write_double fp_;
 
         std::vector<encoding_context,encoding_context_allocator_type> stack_;
@@ -359,7 +358,6 @@ namespace detail {
                            const Allocator& alloc = Allocator())
            : sink_(std::forward<Sink>(sink)), 
              options_(options),
-             indent_char_(options.indent_char()),
              fp_(options.float_format(), options.precision()),
              stack_(alloc)
         {
@@ -1084,14 +1082,7 @@ namespace detail {
             sink_.append(options_.new_line_chars().data(),options_.new_line_chars().length());
             for (int i = 0; i < indent_amount_; ++i)
             {
-                if (options_.indent_chars().empty())
-                {
-                    sink_.push_back(indent_char_);
-                }
-                else
-                {
-                    sink_.append(options_.indent_chars().data(), options_.indent_chars().length());
-                }
+                sink_.append(options_.indent_chars().data(), options_.indent_chars().length());
             }
             column_ = indent_amount_ * options_.new_line_chars().length();
         }
@@ -1101,14 +1092,7 @@ namespace detail {
             sink_.append(options_.new_line_chars().data(),options_.new_line_chars().length());
             for (std::size_t i = 0; i < len; ++i)
             {
-                if (options_.indent_chars().empty())
-                {
-                    sink_.push_back(indent_char_);
-                }
-                else
-                {
-                    sink_.append(options_.indent_chars().data(), options_.indent_chars().length());
-                }
+                sink_.append(options_.indent_chars().data(), options_.indent_chars().length());
             }
             column_ = len;
         }

--- a/include/jsoncons/json_options.hpp
+++ b/include/jsoncons/json_options.hpp
@@ -339,7 +339,6 @@ private:
     uint8_t indent_size_{indent_size_default};
     std::size_t line_length_limit_{line_length_limit_default};
     string_type new_line_chars_;
-    char_type indent_char_;
     string_type after_key_chars_;
     string_type indent_chars_;
 public:
@@ -357,10 +356,10 @@ public:
           array_array_line_splits_(line_split_kind::multi_line),
           array_object_line_splits_(line_split_kind::multi_line),
           spaces_around_colon_(spaces_option::space_after),
-          spaces_around_comma_(spaces_option::space_after),
-          indent_char_(' ')
+          spaces_around_comma_(spaces_option::space_after)
     {
         new_line_chars_.push_back('\n');
+        indent_chars_.push_back(' ');
     }
 
     basic_json_encode_options(const basic_json_encode_options&) = default;
@@ -385,7 +384,6 @@ public:
           indent_size_(other.indent_size_),
           line_length_limit_(other.line_length_limit_),
           new_line_chars_(std::move(other.new_line_chars_)),
-          indent_char_(other.indent_char_),
           after_key_chars_(std::move(other.after_key_chars_)),
           indent_chars_(std::move(other.indent_chars_))
     {
@@ -434,12 +432,7 @@ public:
         return spaces_around_comma_;
     }
 
-    char_type indent_char() const 
-    {
-        return indent_char_;
-    }
-
-    bool pad_inside_object_braces() const 
+    bool pad_inside_object_braces() const
     {
         return pad_inside_object_braces_;
     }
@@ -645,7 +638,7 @@ public:
 
     basic_json_options& indent_char(char_type value)
     {
-        this->indent_char_ = value;
+        this->indent_chars_ = value;
         return *this;
     }
 

--- a/include/jsoncons/utility/bigint.hpp
+++ b/include/jsoncons/utility/bigint.hpp
@@ -287,6 +287,11 @@ public:
         ::new (&inlined_) inlined_storage();
     }
 
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+
     bigint_storage(const bigint_storage& other)
         : word_allocator_type(other.get_allocator())
     {
@@ -299,6 +304,10 @@ public:
             ::new (&allocated_) allocated_storage(other.allocated_, get_allocator());
         }
     }
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
     bigint_storage(const bigint_storage& other, const Allocator& alloc)
         : word_allocator_type(alloc)


### PR DESCRIPTION
pr drops a commit for memory usage computation which is now in dragonfly

dropped commit: 120a781d4